### PR TITLE
[Feat] 이슈 리스트에 api 연결

### DIFF
--- a/src/components/domain/issue/IssueList.tsx
+++ b/src/components/domain/issue/IssueList.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useState } from 'react';
 
+import { IssueList as IssueListType, getIssues } from '@/apis';
 import { IssueListItem } from '@/components/domain/issue';
 import { Issue } from '@/types/issue';
 
@@ -8,13 +9,14 @@ const TERM_OF_AD = 4;
 // TODO 이슈 페이지에서 IssueList 리턴
 const IssueList = () => {
   const [isFetching, setIsFetching] = useState(false);
-  const [issues, setIssues] = useState<Issue[]>(dummy); // FIXME api에 맞는 타입으로 변경
+  const [issues, setIssues] = useState<IssueListType>([]);
 
   useEffect(() => {
     const fetchIssues = async () => {
       setIsFetching(true);
       try {
-        // TODO api 요청
+        const issueDatas = await getIssues(1); // TODO page 바꾸기
+        setIssues(issueDatas);
       } catch {
         alert('데이터를 불러오는데 실패했습니다.');
       } finally {
@@ -24,14 +26,26 @@ const IssueList = () => {
     fetchIssues();
   }, []);
 
+  const parseIssue = (issue: IssueListType[number]): Issue => {
+    return {
+      issueNumber: issue.number,
+      title: issue.title,
+      userName: issue.user?.login ?? 'unknown user',
+      createdAt: issue.created_at,
+      comments: issue.comments,
+      avatarUrl: issue.user?.avatar_url ?? '',
+      body: issue.body,
+    };
+  };
+
   return (
     <>
       {/* TODO 로딩 컴포넌트 넣기 */}
       {isFetching && '로딩중'}
       <ul>
         {issues.map((issue, index) => (
-          <Fragment key={issue.issueNumber}>
-            <IssueListItem issue={issue} />
+          <Fragment key={issue.number}>
+            <IssueListItem issue={parseIssue(issue)} />
             {/* TODO 광고 컴포넌트 넣기 */}
             {(index + 1) % TERM_OF_AD === 0 && '광고'}
           </Fragment>
@@ -42,97 +56,3 @@ const IssueList = () => {
 };
 
 export default IssueList;
-
-// TODO api 연결 후 더미데이터 삭제
-const dummy = [
-  {
-    issueNumber: 1,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 2,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 3,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 4,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 5,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 6,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 7,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 8,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 9,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-  {
-    issueNumber: 10,
-    title: 'title is ittile',
-    userName: 'name',
-    createdAt: new Date(),
-    comments: 23,
-    avatarUrl: '',
-    body: 'string',
-  },
-];

--- a/src/types/issue.ts
+++ b/src/types/issue.ts
@@ -1,9 +1,13 @@
+import { IssueList } from '@/apis';
+
+type IssueListItem = IssueList[number];
+
 export interface Issue {
-  issueNumber: number;
-  title: string;
-  userName: string;
-  createdAt: Date | string;
-  comments: number;
-  avatarUrl: string;
-  body: string;
+  issueNumber: IssueListItem['number'];
+  title: IssueListItem['title'];
+  userName: string; // FIXME user 타입 활용하는 방법
+  createdAt: IssueListItem['created_at'];
+  comments: IssueListItem['comments'];
+  avatarUrl: string; // FIXME user 타입 활용하는 방법
+  body: IssueListItem['body'];
 }


### PR DESCRIPTION
<!-- PR 제목입니다. 우선은 커밋 컨벤션 따라갑시다! -->
<!-- [Feat] 어쩌구 저쩌구 -->
<!-- [Fix] 어쩌구 저쩌구 -->

## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [x] Feature
- [ ] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용

<!-- 작업 내용을 작성합니다 -->

- IssueList 컴포넌트 useEffect 내부에서 api 호출하여 issues 셋팅하고 렌더링합니다.

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)

<!-- 없다면 적지 않으셔도 됩니다. -->

- 구현 필요한 부분은 주석 처리 해놨습니다.
- 혹시 중첩된 타입 가져오는 방법 아시는 분 있을까요?
  `IssueListItem['user']` 내부에 있는 닉네임 타입을 가져오고 싶은데 `IssueListItem['user']['닉네임']`으로는 참조가 안되네요.
  <img width="576" alt="스크린샷 2023-08-31 오후 5 14 31" src="https://github.com/pre-onboarding-12th-team3/pre-onboarding-12th-2-3/assets/69228045/1902b664-ea92-480d-8fe7-d967e5394b50">

