### PR TITLE
[Fix][Refactor] 타입 에러 해결 및 이슈 파싱 함수 유틸로 분리

### DIFF
--- a/src/components/domain/issue/IssueList.tsx
+++ b/src/components/domain/issue/IssueList.tsx
@@ -2,7 +2,7 @@ import { Fragment, useEffect, useState } from 'react';
 
 import { IssueList as IssueListType, getIssues } from '@/apis';
 import { IssueListItem } from '@/components/domain/issue';
-import { Issue } from '@/types/issue';
+import { parseIssue } from '@/utils';
 
 const TERM_OF_AD = 4;
 
@@ -25,18 +25,6 @@ const IssueList = () => {
     };
     fetchIssues();
   }, []);
-
-  const parseIssue = (issue: IssueListType[number]): Issue => {
-    return {
-      issueNumber: issue.number,
-      title: issue.title,
-      userName: issue.user?.login ?? 'unknown user',
-      createdAt: issue.created_at,
-      comments: issue.comments,
-      avatarUrl: issue.user?.avatar_url ?? '',
-      body: issue.body,
-    };
-  };
 
   return (
     <>

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import styled from 'styled-components';
+import { default as styled } from 'styled-components';
 
-import { IssueDetail, getIssueDetail } from '@/apis';
+import { getIssueDetail } from '@/apis';
 import { MarkdownViewer } from '@/components/common';
 import { IssueInfo } from '@/components/domain/issue';
 import { Issue } from '@/types/issue';
+import { parseIssue } from '@/utils';
 
 const DetailPage = () => {
-  const [issues, setIssues] = useState<Issue>();
+  const [issue, setIssue] = useState<Issue>();
   const [isLoading, setIsLoading] = useState(false);
   const { id } = useParams();
   useEffect(() => {
@@ -17,8 +18,8 @@ const DetailPage = () => {
         if (id) {
           setIsLoading(true);
           const response = await getIssueDetail(id);
-          const filterdIssue = getFilteredIssue(response);
-          setIssues(filterdIssue);
+          const parsedIssue = parseIssue(response);
+          setIssue(parsedIssue);
           setIsLoading(false);
         }
       } catch (error) {
@@ -31,13 +32,13 @@ const DetailPage = () => {
 
   return (
     <>
-      {!isLoading && issues ? (
+      {!isLoading && issue ? (
         <>
           <Layout>
-            <ProfileImg src={issues.avatarUrl} alt="avatar" />
-            <IssueInfo issue={issues}></IssueInfo>
+            <ProfileImg src={issue.avatarUrl ?? ''} alt="avatar" />
+            <IssueInfo issue={issue}></IssueInfo>
           </Layout>
-          <MarkdownViewer content={issues.body}></MarkdownViewer>
+          <MarkdownViewer content={issue.body ?? ''}></MarkdownViewer>
         </>
       ) : (
         // 로딩 이미지 추가예정
@@ -46,15 +47,6 @@ const DetailPage = () => {
     </>
   );
 };
-const getFilteredIssue = (issue: IssueDetail): Issue => ({
-  issueNumber: issue.number,
-  userName: issue.user ? issue.user.login : '알 수 없음',
-  title: issue.title,
-  createdAt: new Date(issue.created_at),
-  comments: issue.comments,
-  avatarUrl: issue.user ? issue.user.avatar_url : 'https://i.stack.imgur.com/frlIf.png',
-  body: issue.body ?? '',
-});
 
 const Layout = styled.section`
   display: flex;

--- a/src/types/issue.ts
+++ b/src/types/issue.ts
@@ -5,9 +5,9 @@ type IssueListItem = IssueList[number];
 export interface Issue {
   issueNumber: IssueListItem['number'];
   title: IssueListItem['title'];
-  userName: string; // FIXME user 타입 활용하는 방법
+  userName: Exclude<IssueListItem['user'], null>['login'] | null;
   createdAt: IssueListItem['created_at'];
   comments: IssueListItem['comments'];
-  avatarUrl: string; // FIXME user 타입 활용하는 방법
+  avatarUrl: Exclude<IssueListItem['user'], null>['avatar_url'] | null;
   body: IssueListItem['body'];
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as getFormatDateString } from './getFormatDateString';
+export { default as parseIssue } from './parseIssue';

--- a/src/utils/parseIssue.ts
+++ b/src/utils/parseIssue.ts
@@ -1,0 +1,16 @@
+import { IssueList } from '@/apis';
+import { Issue } from '@/types/issue';
+
+const parseIssue = (issue: IssueList[number]): Issue => {
+  return {
+    issueNumber: issue.number,
+    title: issue.title,
+    userName: issue.user?.login ?? 'unknown user',
+    createdAt: issue.created_at,
+    comments: issue.comments,
+    avatarUrl: issue.user?.avatar_url ?? '',
+    body: issue.body ?? '',
+  };
+};
+
+export default parseIssue;


### PR DESCRIPTION
<!-- PR 제목입니다. 우선은 커밋 컨벤션 따라갑시다! -->
<!-- [Feat] 어쩌구 저쩌구 -->
<!-- [Fix] 어쩌구 저쩌구 -->

## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [ ] Feature
- [x] BugFix
- [x] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용

<!-- 작업 내용을 작성합니다 -->

- MarkdownViewer에서 발생하는 props 타입 에러 해결
- 파싱 함수 유틸로 분리 (IssueList, DetailPage 두 곳에서 사용됨)

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)

<!-- 없다면 적지 않으셔도 됩니다. -->

- 로직은 건드리지 않았고 타입 관련 부분만 수정했습니다~
