### PR TITLE
[Feat] 메인 페이지에 이슈 리스트 렌더, 이슈 아이템과 디테일 페이지 연결

### DIFF
--- a/src/components/domain/issue/IssueList.tsx
+++ b/src/components/domain/issue/IssueList.tsx
@@ -10,19 +10,20 @@ const IssueList = () => {
   const [isFetching, setIsFetching] = useState(false);
   const [issues, setIssues] = useState<IssueListType>([]);
 
+  const fetchIssues = async (/* pageNumber */) => {
+    setIsFetching(true);
+    try {
+      const issueDatas = await getIssues(1); // TODO page 바꾸기
+      setIssues(issueDatas);
+    } catch {
+      alert('데이터를 불러오는데 실패했습니다.');
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
   useEffect(() => {
-    const fetchIssues = async () => {
-      setIsFetching(true);
-      try {
-        const issueDatas = await getIssues(1); // TODO page 바꾸기
-        setIssues(issueDatas);
-      } catch {
-        alert('데이터를 불러오는데 실패했습니다.');
-      } finally {
-        setIsFetching(false);
-      }
-    };
-    fetchIssues();
+    fetchIssues(/* pageNumber */);
   }, []);
 
   return (

--- a/src/components/domain/issue/IssueList.tsx
+++ b/src/components/domain/issue/IssueList.tsx
@@ -6,7 +6,6 @@ import { parseIssue } from '@/utils';
 
 const TERM_OF_AD = 4;
 
-// TODO 이슈 페이지에서 IssueList 리턴
 const IssueList = () => {
   const [isFetching, setIsFetching] = useState(false);
   const [issues, setIssues] = useState<IssueListType>([]);

--- a/src/components/domain/issue/IssueListItem.tsx
+++ b/src/components/domain/issue/IssueListItem.tsx
@@ -1,3 +1,6 @@
+import { Link } from 'react-router-dom';
+import { default as styled } from 'styled-components';
+
 import { IssueInfo } from '@/components/domain/issue';
 import { Issue } from '@/types/issue';
 
@@ -8,12 +11,16 @@ interface Props {
 const IssueListItem = ({ issue }: Props) => {
   return (
     <li>
-      {/* TODO router 작성되면 path 수정하고 Link 넣기 */}
-      {/* <Link to={`/${issue.issueNumber}`}> */}
-      <IssueInfo issue={issue} />
-      {/* </Link> */}
+      <StyledLink to={`/issues/${issue.issueNumber}`}>
+        <IssueInfo issue={issue} />
+      </StyledLink>
     </li>
   );
 };
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+`;
 
 export default IssueListItem;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,11 @@
+import { IssueList } from '@/components/domain/issue';
+
 const MainPage = () => {
-  return <div>MainPage</div>;
+  return (
+    <>
+      <IssueList />
+    </>
+  );
 };
 
 export default MainPage;


### PR DESCRIPTION
<!-- PR 제목입니다. 우선은 커밋 컨벤션 따라갑시다! -->
<!-- [Feat] 어쩌구 저쩌구 -->
<!-- [Fix] 어쩌구 저쩌구 -->

## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [x] Feature
- [ ] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용

<!-- 작업 내용을 작성합니다 -->

- 메인 페이지에 이슈 리스트 렌더
- 이슈 아이템과 디테일 페이지 연결
- IssueList의 useEffect 훅 내부 fetchIssues 함수를 훅 바깥으로 분리

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)

<!-- 없다면 적지 않으셔도 됩니다. -->
